### PR TITLE
Fix inclusive time check in ReportService

### DIFF
--- a/src/main/java/com/chihuahua/sobok/statistics/report/ReportService.java
+++ b/src/main/java/com/chihuahua/sobok/statistics/report/ReportService.java
@@ -321,7 +321,8 @@ public class ReportService {
     }
 
     public boolean isBetween(LocalTime time, LocalTime startTime, LocalTime endTime) {
-        return (time.equals(startTime) || time.isAfter(startTime)) && time.isBefore(endTime);
+        return (time.equals(startTime) || time.isAfter(startTime)) &&
+                (time.equals(endTime) || time.isBefore(endTime));
     }
 
     public String getReportMessage3(Long totalAchievedCount, int currentMonth) {

--- a/src/test/java/com/chihuahua/sobok/ReportServiceTest.java
+++ b/src/test/java/com/chihuahua/sobok/ReportServiceTest.java
@@ -126,6 +126,15 @@ public class ReportServiceTest {
         assertEquals("09:30", result); // 9:30이 2번, 9:00이 1번이므로 9:30이 가장 많음
     }
 
+    @Test
+    @DisplayName("isBetween 메서드는 종료 시간을 포함한다")
+    void isBetweenShouldIncludeEndTime() {
+        assertTrue(reportService.isBetween(
+                java.time.LocalTime.of(11, 59),
+                java.time.LocalTime.of(6, 0),
+                java.time.LocalTime.of(11, 59)));
+    }
+
     // TodoLog 생성 헬퍼 메서드
     private TodoLog createTodoLog(LocalDateTime startTime) {
         TodoLog todoLog = new TodoLog();


### PR DESCRIPTION
## Summary
- fix `isBetween` to treat the end time inclusively
- add regression test for inclusive behaviour

## Testing
- `./gradlew test --console=plain` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841000a50288322a6cda48ec540ea9f