### PR TITLE
feat(kakao): 카카오 로그인 네이티브로 전환(React)

### DIFF
--- a/src/main/java/com/chihuahua/sobok/jwt/JwtUtil.java
+++ b/src/main/java/com/chihuahua/sobok/jwt/JwtUtil.java
@@ -3,6 +3,7 @@ package com.chihuahua.sobok.jwt;
 
 import com.chihuahua.sobok.member.MyUserDetailsService;
 import com.chihuahua.sobok.oauth.AppleUserInfo;
+import com.chihuahua.sobok.oauth.KakaoUserInfo;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
@@ -172,6 +173,39 @@ public class JwtUtil {
         .subject(userInfo.getSub())
         .claim("email", userInfo.getEmail())
         .claim("provider", "apple")
+        .claim("loginType", "native")
+        .issuedAt(now)
+        .expiration(expiration)
+        .signWith(key)
+        .compact();
+  }
+
+  // 카카오 네이티브 로그인용 토큰 생성
+  public String createTokenForKakaoUser(KakaoUserInfo userInfo) {
+    Date now = new Date();
+    Date expiration = new Date(now.getTime() + ACCESS_TOKEN_EXPIRATION);
+
+    return Jwts.builder()
+        .subject(userInfo.getId())
+        .claim("email", userInfo.getEmail())
+        .claim("nickname", userInfo.getNickname())
+        .claim("provider", "kakao")
+        .claim("loginType", "native")
+        .issuedAt(now)
+        .expiration(expiration)
+        .signWith(key)
+        .compact();
+  }
+
+  public String createRefreshTokenForKakaoUser(KakaoUserInfo userInfo) {
+    Date now = new Date();
+    Date expiration = new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION);
+
+    return Jwts.builder()
+        .subject(userInfo.getId())
+        .claim("email", userInfo.getEmail())
+        .claim("nickname", userInfo.getNickname())
+        .claim("provider", "kakao")
         .claim("loginType", "native")
         .issuedAt(now)
         .expiration(expiration)

--- a/src/main/java/com/chihuahua/sobok/member/MemberController.java
+++ b/src/main/java/com/chihuahua/sobok/member/MemberController.java
@@ -117,10 +117,10 @@ public class MemberController {
     return ResponseEntity.ok(response);
   }
 
-  // Apple OAuth 회원의 추가 정보 입력
-  @PutMapping("/oauth/apple/additional-info")
+  // Apple / 카카오 OAuth 회원의 추가 정보 입력
+  @PutMapping("/oauth/additional-info")
   public ResponseEntity<Map<String, Object>> updateAppleOauthAdditionalInfo(
-      @RequestBody AppleOauthAdditionalInfoDto additionalInfoDto) {
+      @RequestBody OauthAdditionalInfoDto additionalInfoDto) {
     Member member = memberService.getMember();
     memberService.updateAppleOauthAdditionalInfo(member, additionalInfoDto);
 

--- a/src/main/java/com/chihuahua/sobok/member/MemberController.java
+++ b/src/main/java/com/chihuahua/sobok/member/MemberController.java
@@ -117,12 +117,12 @@ public class MemberController {
     return ResponseEntity.ok(response);
   }
 
-  // Apple / 카카오 OAuth 회원의 추가 정보 입력
+  // Apple, 카카오 OAuth 회원의 추가 정보 입력
   @PutMapping("/oauth/additional-info")
-  public ResponseEntity<Map<String, Object>> updateAppleOauthAdditionalInfo(
+  public ResponseEntity<Map<String, Object>> updateOauthAdditionalInfo(
       @RequestBody OauthAdditionalInfoDto additionalInfoDto) {
     Member member = memberService.getMember();
-    memberService.updateAppleOauthAdditionalInfo(member, additionalInfoDto);
+    memberService.updateOauthAdditionalInfo(member, additionalInfoDto);
 
     Map<String, Object> response = new HashMap<>();
     response.put("message", "추가 정보 입력 완료");

--- a/src/main/java/com/chihuahua/sobok/member/MemberService.java
+++ b/src/main/java/com/chihuahua/sobok/member/MemberService.java
@@ -366,7 +366,7 @@ public class MemberService {
   }
 
   // Apple OAuth 회원의 추가 정보 입력
-  public void updateAppleOauthAdditionalInfo(Member member,
+  public void updateOauthAdditionalInfo(Member member,
       OauthAdditionalInfoDto additionalInfoDto) {
     // OAuth 회원인지 확인
     if (!Boolean.TRUE.equals(member.getIsOauth())) {

--- a/src/main/java/com/chihuahua/sobok/member/MemberService.java
+++ b/src/main/java/com/chihuahua/sobok/member/MemberService.java
@@ -252,6 +252,14 @@ public class MemberService {
       return oauthAccount.getMember();
     }
 
+    // 카카오 네이티브 로그인인 경우
+    if ("native".equals(loginType) && "kakao".equals(provider)) {
+      String kakaoId = claims.getSubject();
+      OauthAccount oauthAccount = oauthAccountRepository.findByOauthIdAndProvider(kakaoId, "kakao")
+          .orElseThrow(() -> new UnauthorizedException("카카오 OAuth 계정을 찾을 수 없습니다."));
+      return oauthAccount.getMember();
+    }
+
     // 일반 로그인 및 OAuth 로그인인 경우
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     if (authentication == null || authentication.getPrincipal() instanceof String) {

--- a/src/main/java/com/chihuahua/sobok/member/MemberService.java
+++ b/src/main/java/com/chihuahua/sobok/member/MemberService.java
@@ -367,7 +367,7 @@ public class MemberService {
 
   // Apple OAuth 회원의 추가 정보 입력
   public void updateAppleOauthAdditionalInfo(Member member,
-      AppleOauthAdditionalInfoDto additionalInfoDto) {
+      OauthAdditionalInfoDto additionalInfoDto) {
     // OAuth 회원인지 확인
     if (!Boolean.TRUE.equals(member.getIsOauth())) {
       throw new BadRequestException("OAuth 회원이 아닙니다.");

--- a/src/main/java/com/chihuahua/sobok/member/OauthAdditionalInfoDto.java
+++ b/src/main/java/com/chihuahua/sobok/member/OauthAdditionalInfoDto.java
@@ -5,7 +5,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class AppleOauthAdditionalInfoDto {
+public class OauthAdditionalInfoDto {
 
   private String name;
   private String displayName;

--- a/src/main/java/com/chihuahua/sobok/oauth/KakaoNativeLoginController.java
+++ b/src/main/java/com/chihuahua/sobok/oauth/KakaoNativeLoginController.java
@@ -58,7 +58,6 @@ public class KakaoNativeLoginController {
           Member newMember = new Member();
           newMember.setEmail(userInfo.getEmail());
           newMember.setUsername(userInfo.getId()); // 카카오 ID를 username으로 사용
-          newMember.setDisplayName(userInfo.getNickname()); // 카카오 닉네임을 displayName으로 사용
           newMember.setIsOauth(true);
           member = memberRepository.save(newMember);
 
@@ -106,8 +105,6 @@ public class KakaoNativeLoginController {
           "user", Map.of(
               "id", member.getId(),
               "email", member.getEmail(),
-              "name", member.getName(),
-              "displayName", member.getDisplayName(),
               "provider", "kakao",
               "isExistingUser", isExistingUser // 기존 사용자 여부
           )

--- a/src/main/java/com/chihuahua/sobok/oauth/KakaoNativeLoginController.java
+++ b/src/main/java/com/chihuahua/sobok/oauth/KakaoNativeLoginController.java
@@ -1,0 +1,121 @@
+package com.chihuahua.sobok.oauth;
+
+import com.chihuahua.sobok.jwt.JwtUtil;
+import com.chihuahua.sobok.member.Member;
+import com.chihuahua.sobok.member.MemberRepository;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoNativeLoginController {
+
+  private final KakaoTokenVerifier kakaoTokenVerifier;
+  private final JwtUtil jwtUtil;
+  private final OauthAccountRepository oauthAccountRepository;
+  private final MemberRepository memberRepository;
+
+  @PostMapping("/kakao/native")
+  public ResponseEntity<?> kakaoNativeLogin(@RequestBody KakaoNativeLoginRequest request) {
+    try {
+      log.info("카카오 네이티브 로그인 요청 수신");
+
+      // 카카오 액세스 토큰 검증 및 사용자 정보 추출
+      KakaoUserInfo userInfo = kakaoTokenVerifier.verifyAccessToken(request.getAccessToken());
+
+      // 이메일이 null인 경우 처리
+      if (userInfo.getEmail() == null || userInfo.getEmail().trim().isEmpty()) {
+        log.warn("카카오 로그인에서 이메일 정보가 없습니다. id: {}", userInfo.getId());
+        return ResponseEntity.badRequest().body(Map.of("error", "이메일 정보가 필요합니다."));
+      }
+
+      // 기존 OAuth 계정이 있는지 확인
+      Optional<OauthAccount> existingOauthAccount =
+          oauthAccountRepository.findByOauthIdAndProvider(userInfo.getId(), "kakao");
+
+      Member member;
+      boolean isExistingUser = existingOauthAccount.isPresent();
+
+      if (isExistingUser) { // 1. 기존 카카오 OAuth 계정이 있는 경우
+        member = existingOauthAccount.get().getMember();
+
+        log.info("기존 카카오 OAuth 계정으로 로그인: {}", member.getEmail());
+      } else {
+        // 일반 이메일인 경우 (카카오는 이메일 가리기 기능이 없음)
+        Optional<Member> existingMember = memberRepository.findByEmail(userInfo.getEmail());
+
+        if (existingMember.isEmpty()) {
+          // 기존 회원이 없는 경우 - 새 회원 생성
+          Member newMember = new Member();
+          newMember.setEmail(userInfo.getEmail());
+          newMember.setUsername(userInfo.getId()); // 카카오 ID를 username으로 사용
+          newMember.setDisplayName(userInfo.getNickname()); // 카카오 닉네임을 displayName으로 사용
+          newMember.setIsOauth(true);
+          member = memberRepository.save(newMember);
+
+          // OAuth 계정 정보 저장
+          OauthAccount newAccount = new OauthAccount();
+          newAccount.setOauthId(userInfo.getId());
+          newAccount.setProvider("kakao");
+          newAccount.setMember(member);
+          oauthAccountRepository.save(newAccount);
+
+          log.info("새로운 카카오 회원 생성: {}", member.getEmail());
+        } else {
+          // 기존 회원이 있는 경우
+          member = existingMember.get();
+
+          // 이미 카카오 OAuth 계정이 연결되어 있는지 재확인 (다른 id로 등록된 경우)
+          Optional<OauthAccount> existingKakaoAccount =
+              oauthAccountRepository.findByMemberAndProvider(member, "kakao");
+
+          if (existingKakaoAccount.isPresent()) {
+            log.warn(
+                "기존 회원에게 이미 다른 카카오 OAuth 계정이 연결되어 있습니다. email: {}, existing_id: {}, new_id: {}",
+                member.getEmail(), existingKakaoAccount.get().getOauthId(), userInfo.getId());
+            return ResponseEntity.badRequest().body(Map.of("error", "이미 다른 카카오 계정이 연결되어 있습니다."));
+          }
+
+          log.info("기존 회원에 카카오 OAuth 계정 연결: {}", member.getEmail());
+
+          // OAuth 계정 정보 저장
+          OauthAccount newAccount = new OauthAccount();
+          newAccount.setOauthId(userInfo.getId());
+          newAccount.setProvider("kakao");
+          newAccount.setMember(member);
+          oauthAccountRepository.save(newAccount);
+        }
+      }
+
+      // JWT 토큰 생성
+      String accessToken = jwtUtil.createTokenForKakaoUser(userInfo);
+      String refreshToken = jwtUtil.createRefreshTokenForKakaoUser(userInfo);
+
+      return ResponseEntity.ok(Map.of(
+          "accessToken", accessToken,
+          "refreshToken", refreshToken,
+          "user", Map.of(
+              "id", member.getId(),
+              "email", member.getEmail(),
+              "name", member.getName(),
+              "displayName", member.getDisplayName(),
+              "provider", "kakao",
+              "isExistingUser", isExistingUser // 기존 사용자 여부
+          )
+      ));
+
+    } catch (Exception e) {
+      log.error("카카오 네이티브 로그인 실패", e);
+      return ResponseEntity.badRequest().body(Map.of("error", "로그인 실패: " + e.getMessage()));
+    }
+  }
+}

--- a/src/main/java/com/chihuahua/sobok/oauth/KakaoNativeLoginRequest.java
+++ b/src/main/java/com/chihuahua/sobok/oauth/KakaoNativeLoginRequest.java
@@ -1,0 +1,11 @@
+package com.chihuahua.sobok.oauth;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoNativeLoginRequest {
+
+  private String accessToken;
+}

--- a/src/main/java/com/chihuahua/sobok/oauth/KakaoTokenVerifier.java
+++ b/src/main/java/com/chihuahua/sobok/oauth/KakaoTokenVerifier.java
@@ -1,0 +1,74 @@
+package com.chihuahua.sobok.oauth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoTokenVerifier {
+
+  private final RestTemplate restTemplate = new RestTemplate();
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+  public KakaoUserInfo verifyAccessToken(String accessToken) {
+    try {
+      // 카카오 API로 사용자 정보 요청
+      HttpHeaders headers = new HttpHeaders();
+      headers.set("Authorization", "Bearer " + accessToken);
+      headers.set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+      HttpEntity<String> entity = new HttpEntity<>(headers);
+
+      ResponseEntity<String> response = restTemplate.exchange(
+          KAKAO_USER_INFO_URL,
+          HttpMethod.GET,
+          entity,
+          String.class
+      );
+
+      if (!response.getStatusCode().is2xxSuccessful()) {
+        throw new RuntimeException("카카오 사용자 정보 조회 실패: " + response.getStatusCode());
+      }
+
+      // JSON 응답 파싱
+      JsonNode jsonNode = objectMapper.readTree(response.getBody());
+
+      KakaoUserInfo userInfo = new KakaoUserInfo();
+      userInfo.setId(jsonNode.get("id").asText());
+
+      // 카카오_계정 정보 추출
+      JsonNode kakaoAccount = jsonNode.get("kakao_account");
+      if (kakaoAccount != null) {
+        if (kakaoAccount.has("email")) {
+          userInfo.setEmail(kakaoAccount.get("email").asText());
+        }
+
+        // 프로필 정보 추출
+        JsonNode profile = kakaoAccount.get("profile");
+        if (profile != null) {
+          if (profile.has("nickname")) {
+            userInfo.setNickname(profile.get("nickname").asText());
+          }
+        }
+      }
+
+      log.info("카카오 사용자 정보 조회 성공: id={}, email={}", userInfo.getId(), userInfo.getEmail());
+      return userInfo;
+
+    } catch (Exception e) {
+      log.error("카카오 액세스 토큰 검증 실패", e);
+      throw new RuntimeException("카카오 액세스 토큰 검증 실패: " + e.getMessage());
+    }
+  }
+}

--- a/src/main/java/com/chihuahua/sobok/oauth/KakaoTokenVerifier.java
+++ b/src/main/java/com/chihuahua/sobok/oauth/KakaoTokenVerifier.java
@@ -54,13 +54,13 @@ public class KakaoTokenVerifier {
           userInfo.setEmail(kakaoAccount.get("email").asText());
         }
 
-        // 프로필 정보 추출
-        JsonNode profile = kakaoAccount.get("profile");
-        if (profile != null) {
-          if (profile.has("nickname")) {
-            userInfo.setNickname(profile.get("nickname").asText());
-          }
-        }
+        // 프로필 정보 추출(닉네임 사용 여부에 따라 주석 처리)
+//        JsonNode profile = kakaoAccount.get("profile");
+//        if (profile != null) {
+//          if (profile.has("nickname")) {
+//            userInfo.setNickname(profile.get("nickname").asText());
+//          }
+//        }
       }
 
       log.info("카카오 사용자 정보 조회 성공: id={}, email={}", userInfo.getId(), userInfo.getEmail());

--- a/src/main/java/com/chihuahua/sobok/oauth/KakaoUserInfo.java
+++ b/src/main/java/com/chihuahua/sobok/oauth/KakaoUserInfo.java
@@ -1,0 +1,13 @@
+package com.chihuahua.sobok.oauth;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoUserInfo {
+
+  private String id; // 카카오 고유 ID (sub 역할)
+  private String email;
+  private String nickname;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for native Kakao login, allowing users to authenticate using their Kakao account.
  * Introduced a new login endpoint for Kakao native login.
  * Implemented automatic creation and linking of user accounts with Kakao OAuth information.
  * Provided JWT access and refresh token generation for Kakao native login users.
  * Generalized OAuth additional info update endpoint to support multiple providers.

* **Bug Fixes**
  * Improved member retrieval logic to handle Kakao native login scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->