### PR TITLE
fix(apple): 유저 정보 가져올 때 NullCheck

### DIFF
--- a/src/main/java/com/chihuahua/sobok/member/MemberService.java
+++ b/src/main/java/com/chihuahua/sobok/member/MemberService.java
@@ -85,19 +85,22 @@ public class MemberService {
   // MemberController에서 유저 정보 조회
   public Map<String, Object> getUserInfo(Member member) {
     Map<String, Object> response = new HashMap<>();
-    response.put("username", member.getUsername());
+    response.put("username", member.getUsername() != null ? member.getUsername() : "");
     response.put("id", member.getId());
-    response.put("name", member.getName());
-    response.put("displayName", member.getDisplayName());
-    response.put("point", member.getPoint());
-    response.put("email", member.getEmail());
-    response.put("phoneNumber", member.getPhoneNumber());
-    response.put("birth", member.getBirth());
-    response.put("isPremium", member.getIsPremium());
-    response.put("totalAchievedTime", member.getTotalAchievedTime());
-    response.put("totalAccountBalance", member.getTotalAccountBalance());
-    response.put("weeklyRoutineTime", member.getWeeklyRoutineTime());
-    if (member.getIsPremium()) {
+    response.put("name", member.getName() != null ? member.getName() : "");
+    response.put("displayName", member.getDisplayName() != null ? member.getDisplayName() : "");
+    response.put("point", member.getPoint() != null ? member.getPoint() : 0);
+    response.put("email", member.getEmail() != null ? member.getEmail() : "");
+    response.put("phoneNumber", member.getPhoneNumber() != null ? member.getPhoneNumber() : "");
+    response.put("birth", member.getBirth() != null ? member.getBirth() : "");
+    response.put("isPremium", member.getIsPremium() != null ? member.getIsPremium() : false);
+    response.put("totalAchievedTime",
+        member.getTotalAchievedTime() != null ? member.getTotalAchievedTime() : 0);
+    response.put("totalAccountBalance",
+        member.getTotalAccountBalance() != null ? member.getTotalAccountBalance() : 0);
+    response.put("weeklyRoutineTime",
+        member.getWeeklyRoutineTime() != null ? member.getWeeklyRoutineTime() : 0);
+    if (Boolean.TRUE.equals(member.getIsPremium())) {
       Premium premium = premiumRepository.findByMemberAndEndAtAfter(member, LocalDate.now())
           .orElseThrow(() -> new IllegalArgumentException("프리미엄 정보를 찾을 수 없습니다."));
       response.put("premiumEndAt", premium.getEndAt());

--- a/src/main/java/com/chihuahua/sobok/oauth/AppleNativeLoginController.java
+++ b/src/main/java/com/chihuahua/sobok/oauth/AppleNativeLoginController.java
@@ -124,8 +124,9 @@ public class AppleNativeLoginController {
           "refreshToken", refreshToken,
           "user", Map.of(
               "id", member.getId(),
-              "email", member.getEmail(),
-              "name", member.getName(),
+              "email", member.getEmail() != null ? member.getEmail() : "",
+              "name", member.getName() != null ? member.getName() : "",
+              "displayName", member.getDisplayName() != null ? member.getDisplayName() : "",
               "provider", "apple",
               "isExistingUser", isExistingUser // 기존 사용자 여부
           )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of user information to prevent null values in profile fields such as username, name, display name, points, email, phone number, birthdate, premium status, achieved time, account balance, and routine time.
  * Ensured that login responses always return non-null values for email, name, and display name, providing empty strings when information is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->