### PR TITLE
feat(terraform): add OCI infrastructure as code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
 HELP.md
+
+### Terraform ###
+terraform/terraform.tfvars
+terraform/.terraform/
+terraform/.terraform.lock.hcl
+terraform/terraform.tfstate
+terraform/terraform.tfstate.backup
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,30 @@
+# ──────────────────────────────────────────────
+# Dynamic Group
+# 인스턴스가 OCI API를 직접 호출할 수 있도록 (Instance Principal)
+# 시크릿 다운로드 스크립트(.platform/hooks/prebuild/03_download_secrets.sh)에서 사용
+# ──────────────────────────────────────────────
+
+resource "oci_identity_dynamic_group" "app" {
+  # Dynamic Group은 tenancy 레벨에서 생성
+  compartment_id = var.tenancy_ocid
+  name           = "${var.app_name}-instance-group"
+  description    = "${var.app_name} compute instances (Instance Principal)"
+
+  # compartment 내 모든 인스턴스를 포함
+  matching_rule = "ANY {instance.compartment.id = '${var.compartment_ocid}'}"
+}
+
+# ──────────────────────────────────────────────
+# IAM Policy
+# Dynamic Group이 Object Storage(Sobok-env)를 읽을 수 있도록 허용
+# ──────────────────────────────────────────────
+
+resource "oci_identity_policy" "app_object_storage" {
+  compartment_id = var.compartment_ocid
+  name           = "${var.app_name}-object-storage-policy"
+  description    = "Allow ${var.app_name} instances to read secrets from Object Storage"
+
+  statements = [
+    "Allow dynamic-group ${oci_identity_dynamic_group.app.name} to read objects in compartment id ${var.compartment_ocid} where target.bucket.name='Sobok-env'",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,165 @@
+terraform {
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "oci" {
+  tenancy_ocid        = var.tenancy_ocid
+  region              = var.region
+  config_file_profile = var.config_file_profile
+}
+
+# ──────────────────────────────────────────────
+# Data Sources
+# ──────────────────────────────────────────────
+
+data "oci_identity_availability_domains" "ads" {
+  compartment_id = var.tenancy_ocid
+}
+
+# Ubuntu 22.04 최신 이미지 (ARM용)
+data "oci_core_images" "ubuntu" {
+  compartment_id           = var.compartment_ocid
+  operating_system         = "Canonical Ubuntu"
+  operating_system_version = "22.04"
+  shape                    = var.instance_shape
+  sort_by                  = "TIMECREATED"
+  sort_order               = "DESC"
+}
+
+# ──────────────────────────────────────────────
+# VCN
+# ──────────────────────────────────────────────
+
+resource "oci_core_vcn" "main" {
+  compartment_id = var.compartment_ocid
+  cidr_block     = "10.0.0.0/16"
+  display_name   = "${var.app_name}-vcn"
+  dns_label      = var.app_name
+}
+
+resource "oci_core_internet_gateway" "main" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.main.id
+  display_name   = "${var.app_name}-igw"
+  enabled        = true
+}
+
+resource "oci_core_route_table" "main" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.main.id
+  display_name   = "${var.app_name}-rt"
+
+  route_rules {
+    destination       = "0.0.0.0/0"
+    network_entity_id = oci_core_internet_gateway.main.id
+  }
+}
+
+# ──────────────────────────────────────────────
+# Security List (방화벽)
+# ──────────────────────────────────────────────
+
+resource "oci_core_security_list" "main" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.main.id
+  display_name   = "${var.app_name}-sl"
+
+  # Egress: 모든 아웃바운드 허용
+  egress_security_rules {
+    destination = "0.0.0.0/0"
+    protocol    = "all"
+  }
+
+  # SSH
+  ingress_security_rules {
+    protocol = "6" # TCP
+    source   = "0.0.0.0/0"
+    tcp_options {
+      min = 22
+      max = 22
+    }
+  }
+
+  # HTTP (Caddy가 HTTPS로 리다이렉트)
+  ingress_security_rules {
+    protocol = "6"
+    source   = "0.0.0.0/0"
+    tcp_options {
+      min = 80
+      max = 80
+    }
+  }
+
+  # HTTPS
+  ingress_security_rules {
+    protocol = "6"
+    source   = "0.0.0.0/0"
+    tcp_options {
+      min = 443
+      max = 443
+    }
+  }
+
+  # ICMP (Path MTU Discovery)
+  ingress_security_rules {
+    protocol = "1"
+    source   = "0.0.0.0/0"
+    icmp_options {
+      type = 3
+      code = 4
+    }
+  }
+}
+
+# ──────────────────────────────────────────────
+# Subnet
+# ──────────────────────────────────────────────
+
+resource "oci_core_subnet" "main" {
+  compartment_id    = var.compartment_ocid
+  vcn_id            = oci_core_vcn.main.id
+  cidr_block        = "10.0.1.0/24"
+  display_name      = "${var.app_name}-subnet"
+  dns_label         = "${var.app_name}sub"
+  route_table_id    = oci_core_route_table.main.id
+  security_list_ids = [oci_core_security_list.main.id]
+}
+
+# ──────────────────────────────────────────────
+# Compute Instance
+# ──────────────────────────────────────────────
+
+resource "oci_core_instance" "app" {
+  compartment_id      = var.compartment_ocid
+  availability_domain = data.oci_identity_availability_domains.ads.availability_domains[0].name
+  shape               = var.instance_shape
+  display_name        = "${var.app_name}-server"
+
+  shape_config {
+    ocpus         = var.instance_ocpus
+    memory_in_gbs = var.instance_memory_in_gbs
+  }
+
+  source_details {
+    source_type             = "image"
+    source_id               = data.oci_core_images.ubuntu.images[0].id
+    boot_volume_size_in_gbs = 50
+  }
+
+  create_vnic_details {
+    subnet_id        = oci_core_subnet.main.id
+    assign_public_ip = true
+    display_name     = "${var.app_name}-vnic"
+    hostname_label   = var.app_name
+  }
+
+  metadata = {
+    ssh_authorized_keys = var.ssh_public_key
+    user_data           = base64encode(file("${path.module}/user_data.sh"))
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "instance_public_ip" {
+  description = "인스턴스 공인 IP — DNS A 레코드 및 GitHub Secret OCI_HOST에 설정"
+  value       = oci_core_instance.app.public_ip
+}
+
+output "instance_id" {
+  description = "인스턴스 OCID"
+  value       = oci_core_instance.app.id
+}
+
+output "object_storage_namespace" {
+  description = "Object Storage 네임스페이스 — 03_download_secrets.sh의 OCI_NAMESPACE 값"
+  value       = data.oci_objectstorage_namespace.ns.namespace
+}
+
+output "bucket_name" {
+  description = "시크릿 버킷 이름"
+  value       = oci_objectstorage_bucket.secrets.name
+}
+
+output "ssh_command" {
+  description = "인스턴스 SSH 접속 명령어"
+  value       = "ssh ubuntu@${oci_core_instance.app.public_ip}"
+}

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -1,0 +1,13 @@
+data "oci_objectstorage_namespace" "ns" {
+  compartment_id = var.compartment_ocid
+}
+
+# 시크릿 파일(.env, firebase-adminsdk.json) 보관 버킷
+# 03_download_secrets.sh에서 이 버킷에서 파일을 다운로드함
+resource "oci_objectstorage_bucket" "secrets" {
+  compartment_id = var.compartment_ocid
+  namespace      = data.oci_objectstorage_namespace.ns.namespace
+  name           = "Sobok-env"
+  access_type    = "NoPublicAccess"
+  versioning     = "Enabled"
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,26 @@
+# terraform.tfvars.example
+# 복사 후 terraform.tfvars로 이름 변경하고 실제 값 입력
+# terraform.tfvars는 .gitignore에 추가할 것
+
+# OCI 콘솔 → Profile → Tenancy → OCID
+tenancy_ocid = "ocid1.tenancy.oc1..aaaa..."
+
+# OCI 콘솔 → Identity → Compartments
+compartment_ocid = "ocid1.compartment.oc1..aaaa..."
+
+# OCI 리전 (춘천: ap-chuncheon-1, 서울: ap-seoul-1)
+region = "ap-chuncheon-1"
+
+# ARM 무료 티어 (월 최대 3,000시간 무료)
+instance_shape         = "VM.Standard.A1.Flex"
+instance_ocpus         = 1
+instance_memory_in_gbs = 6
+
+# cat ~/.ssh/id_rsa.pub 또는 OCI 키쌍 공개키
+ssh_public_key = "ssh-rsa AAAA..."
+
+# 앱 이름 (리소스 이름 prefix)
+app_name = "sobok"
+
+# ~/.oci/config 파일의 프로파일 이름
+config_file_profile = "DEFAULT"

--- a/terraform/user_data.sh
+++ b/terraform/user_data.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# cloud-init: OCI Ubuntu 22.04 인스턴스 초기 세팅
+set -euo pipefail
+exec > /var/log/user-data.log 2>&1
+
+echo "[INFO] === 초기화 시작 ==="
+
+# ──────────────────────────────────────────────
+# 패키지 업데이트
+# ──────────────────────────────────────────────
+apt-get update -y
+apt-get install -y ca-certificates curl gnupg iptables-persistent
+
+# ──────────────────────────────────────────────
+# Docker 설치
+# ──────────────────────────────────────────────
+echo "[INFO] Docker 설치 중..."
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+  | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+chmod a+r /etc/apt/keyrings/docker.gpg
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+  https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+  > /etc/apt/sources.list.d/docker.list
+
+apt-get update -y
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+systemctl enable docker
+systemctl start docker
+usermod -aG docker ubuntu
+echo "[INFO] Docker 설치 완료"
+
+# ──────────────────────────────────────────────
+# 앱 디렉토리 생성
+# ──────────────────────────────────────────────
+mkdir -p /var/app/current
+chown ubuntu:ubuntu /var/app/current
+
+mkdir -p /opt/secrets
+chmod 700 /opt/secrets
+echo "[INFO] 디렉토리 생성 완료"
+
+# ──────────────────────────────────────────────
+# OCI Ubuntu 22.04의 iptables 규칙에 HTTP/HTTPS 추가
+# (Security List에서 허용하더라도 OS 레벨 방화벽도 열어야 함)
+# ──────────────────────────────────────────────
+iptables -I INPUT 6 -m state --state NEW -p tcp --dport 80 -j ACCEPT
+iptables -I INPUT 7 -m state --state NEW -p tcp --dport 443 -j ACCEPT
+netfilter-persistent save
+echo "[INFO] iptables 규칙 추가 완료"
+
+echo "[INFO] === 초기화 완료 ==="

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,50 @@
+variable "tenancy_ocid" {
+  description = "OCI Tenancy OCID"
+  type        = string
+}
+
+variable "compartment_ocid" {
+  description = "리소스를 생성할 Compartment OCID"
+  type        = string
+}
+
+variable "region" {
+  description = "OCI 리전 (예: ap-seoul-1, ap-chuncheon-1)"
+  type        = string
+  default     = "ap-chuncheon-1"
+}
+
+variable "instance_shape" {
+  description = "Compute 인스턴스 Shape (VM.Standard.A1.Flex = ARM 무료 티어)"
+  type        = string
+  default     = "VM.Standard.A1.Flex"
+}
+
+variable "instance_ocpus" {
+  description = "Flexible Shape OCPU 수 (A1 무료 티어: 최대 4)"
+  type        = number
+  default     = 1
+}
+
+variable "instance_memory_in_gbs" {
+  description = "Flexible Shape 메모리 (GB, A1 무료 티어: 최대 24)"
+  type        = number
+  default     = 6
+}
+
+variable "ssh_public_key" {
+  description = "인스턴스 접속용 SSH 공개키"
+  type        = string
+}
+
+variable "app_name" {
+  description = "리소스 이름 prefix"
+  type        = string
+  default     = "sobok"
+}
+
+variable "config_file_profile" {
+  description = "~/.oci/config 파일의 프로파일명"
+  type        = string
+  default     = "DEFAULT"
+}


### PR DESCRIPTION
Add Terraform configuration to provision and manage OCI resources:
- VCN, subnet, internet gateway, route table, security list (ports 22/80/443)
- ARM compute instance (VM.Standard.A1.Flex) with cloud-init for Docker setup
- Object Storage bucket (Sobok-env) for secrets
- Dynamic Group + IAM policy for Instance Principal auth
- .gitignore entries for sensitive Terraform files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Provisions new network, compute, IAM, and Object Storage resources in OCI, which can impact security exposure (public ingress) and incur cost if misconfigured. Changes also introduce Instance Principal permissions for reading from a secrets bucket.
> 
> **Overview**
> Adds a new `terraform/` stack to provision OCI infrastructure: a VCN/subnet with internet gateway + routing, a security list opening `22/80/443` (plus ICMP), and an ARM Ubuntu 22.04 compute instance bootstrapped via `user_data.sh` to install Docker, create app/secrets directories, and open OS-level `80/443` iptables rules.
> 
> Adds Object Storage provisioning for a private, versioned `Sobok-env` bucket and IAM setup (dynamic group + policy) allowing instances to read objects from that bucket via Instance Principal. Updates `.gitignore` to exclude Terraform state/vars and other sensitive artifacts, and includes `terraform.tfvars.example` plus outputs for IP/IDs/bucket info.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fdb3b12b4eab7bffa5479b6456cb6e19f87453b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->